### PR TITLE
MAINT: Fixed minor typos in cancer intervention tutorial

### DIFF
--- a/book/030-tutorial-downstream/080-longitudinal.md
+++ b/book/030-tutorial-downstream/080-longitudinal.md
@@ -40,7 +40,7 @@ genus_table, = use.action(
 Then, to focus on the genera that are likely to display the most interesting
 patterns over time (and to reduce the runtime of the steps that come next), we
 will perform even more filtering. This time we'll apply prevalence and
-abudnance based filtering. Specifically, we'll require that a genus's abundance
+abundance based filtering. Specifically, we'll require that a genus's abundance
 is at least 1% in at least 10% of the samples.
 
 ````{margin}

--- a/book/index.md
+++ b/book/index.md
@@ -8,7 +8,7 @@ on the [QIIME 2 YouTube channel](https://youtube.com/qiime2).
 
 This tutorial is intended to be read like a book, from beginning to end.
 
-This tutorial and the correspnding videos present many new features of QIIME 2
+This tutorial and the corresponding videos present many new features of QIIME 2
 and our education and documentation ecosystem, including:
 
 * The new QIIME 2 [Galaxy](https://usegalaxy.org/)-based graphical user
@@ -157,7 +157,7 @@ including the data set and the written and video tutorials.
 
 The QIIME 2 project is funded in part by:
 * The National Cancer Institute:
-  * [Informatics Technology for Cancer Reserach](https://itcr.cancer.gov/)
+  * [Informatics Technology for Cancer Research](https://itcr.cancer.gov/)
     (1U24CA248454-01) to JGC
   * [The Partnership for Native American Cancer
      Prevention](https://in.nau.edu/nacp/) (U54CA143925 and U54CA143924) to JGC


### PR DESCRIPTION
This PR fixes the minor typos in the cancer intervention tutorial that were pointed out in issue https://github.com/qiime2/docs/issues/552

Merging this will resolve issue https://github.com/qiime2/docs/issues/552