### PR TITLE
MAINT: updates install env with latest amplicon env file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,10 +33,10 @@ jobs:
         auto-update-conda: true
         python-version: 3.8
 
-    - name: install latest QIIME 2 core distro (staging)
+    - name: install latest QIIME 2 amplicon distro (passed)
       run: |
-        envFile=qiime2-2022.11-py38-linux-conda.yml
-        wget https://data.qiime2.org/distro/core/$envFile
+        envFile=qiime2-amplicon-ubuntu-latest-conda.yml
+        wget https://data.qiime2.org/distro/amplicon/$envFile
         conda env create -q -p ./test-env --file $envFile
 
     - name: install dependencies


### PR DESCRIPTION
updates the installed environment used for the tutorial with the latest amplicon environment. cc: @cherman2

data302 links have also been updated to reflect this (PR [here](https://github.com/qiime2/data302/pull/147) for reference).